### PR TITLE
fix double references

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,28 +72,24 @@ var resolveReferencePlaceholders = function (rootDNA, item, key) {
       return clone(resolveValue(rootDNA, item.substr(2)))
     break
 
-    case re.referencePlaceholder.test(item):
-      var matches = item.match(re.referencePlaceholder).sort().filter(filterMatches)
-
-      for (var i in matches) {
-        var match = matches[i].replace(re.referencePlaceholderStrip, '')
-        var value = resolveValue(rootDNA, match)
-        item = item.replace(new RegExp('@{' + match + '}', 'g'), value)
-      }
-      return item
-    break
-
-    case re.processEnv.test(item):
-      var matches = item.match(re.processEnv).sort().filter(filterMatches)
-
-      for (var i in matches) {
-        var match = matches[i].replace(re.processEnvStrip, '')
-        item = item.replace(new RegExp('{\\$' + match + '}', 'g'), process.env[match])
-      }
-      return item
-    break
-
     default:
+      if (re.referencePlaceholder.test(item)) {
+        var matches = item.match(re.referencePlaceholder).sort().filter(filterMatches)
+
+        for (var i in matches) {
+          var match = matches[i].replace(re.referencePlaceholderStrip, '')
+          var value = resolveValue(rootDNA, match)
+          item = item.replace(new RegExp('@{' + match + '}', 'g'), value)
+        }
+      }
+      if (re.processEnv.test(item)) {
+        var matches = item.match(re.processEnv).sort().filter(filterMatches)
+
+        for (var i in matches) {
+          var match = matches[i].replace(re.processEnvStrip, '')
+          item = item.replace(new RegExp('{\\$' + match + '}', 'g'), process.env[match])
+        }
+      }
       return item
     break
   }

--- a/tests/double-references.spec.js
+++ b/tests/double-references.spec.js
@@ -1,0 +1,34 @@
+var test = require('tape').test
+
+test('dna resolve (double references)', function(t) {
+  var dna = {
+    branch: 'value',
+    branch2: '@{branch} and {$ENV_VAR}'
+  }
+
+  process.env.ENV_VAR = 'value2'
+  require('../index')(dna)
+  delete process.env.ENV_VAR
+
+  t.is(dna.branch2, 'value and value2')
+
+  t.end()
+})
+
+test('dna resolve (double references) 2', function(t) {
+  var dna = {
+    branch0: 'end',
+    branch: 'value',
+    branch2: '@{branch} and {$ENV_VAR} ==> @{branch3} but @{branch0}',
+    branch3: '@{branch}'
+  }
+
+  process.env.ENV_VAR = 'value2'
+  require('../index')(dna)
+  delete process.env.ENV_VAR
+
+  t.is(dna.branch2, 'value and value2 ==> value but end')
+  t.is(dna.branch3, 'value')
+
+  t.end()
+})


### PR DESCRIPTION
This PR fixes double references used at the same branch value, ie:

```
dna = { branch: "value", branch2: "@{branch} and {$ENV_VAR}" }
```

Without the PR (and its changes) the above would fail to resolve and the ENV_VAR will be left as it is. The PR changes the implementation so that the branch's value is checked for **both** branch placeholder references and env variables.

Test is also added ;) :shipit: :heart: 